### PR TITLE
Remove City of Avalon fixed-route service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.db
 dmfr.schema.json
+.idea/

--- a/feeds/alerts.goswift.ly.dmfr.json
+++ b/feeds/alerts.goswift.ly.dmfr.json
@@ -77,21 +77,6 @@
       }
     },
     {
-      "id": "f-avalon~ca~rt~alerts",
-      "spec": "gtfs-rt",
-      "urls": {
-        "realtime_alerts": "https://api.goswift.ly/real-time/avalon/gtfs-rt-alerts"
-      },
-      "license": {
-        "url": "https://www.goswift.ly/api-license"
-      },
-      "authorization": {
-        "type": "header",
-        "param_name": "Authorization",
-        "info_url": "https://goswift.ly/realtime-api-key"
-      }
-    },
-    {
       "id": "f-baytowntrolley~fl~rt~alerts",
       "spec": "gtfs-rt",
       "urls": {

--- a/feeds/trilliumtransit.com.dmfr.json
+++ b/feeds/trilliumtransit.com.dmfr.json
@@ -2,39 +2,6 @@
   "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.5.0.json",
   "feeds": [
     {
-      "id": "f-9mgve-avalon~ca~us",
-      "spec": "gtfs",
-      "urls": {
-        "static_current": "https://data.trilliumtransit.com/gtfs/avalon-ca-us/avalon-ca-us.zip"
-      },
-      "license": {
-        "use_without_attribution": "yes",
-        "create_derived_product": "yes"
-      },
-      "operators": [
-        {
-          "onestop_id": "o-9mgve-avalontransit",
-          "name": "Avalon Transit",
-          "website": "http://www.cityofavalon.com/transit",
-          "associated_feeds": [
-            {
-              "gtfs_agency_id": "622"
-            },
-            {
-              "feed_onestop_id": "f-avalon~ca~rt"
-            },
-            {
-              "feed_onestop_id": "f-avalon~ca~rt~alerts"
-            }
-          ],
-          "tags": {
-            "twitter_general": "avalongov",
-            "us_ntd_id": "90249"
-          }
-        }
-      ]
-    },
-    {
       "id": "f-9muq-lagunabeach~ca~us",
       "spec": "gtfs",
       "urls": {

--- a/feeds/tu-vp.goswift.ly.dmfr.json
+++ b/feeds/tu-vp.goswift.ly.dmfr.json
@@ -258,22 +258,6 @@
       }
     },
     {
-      "id": "f-avalon~ca~rt",
-      "spec": "gtfs-rt",
-      "urls": {
-        "realtime_vehicle_positions": "https://api.goswift.ly/real-time/avalon/gtfs-rt-vehicle-positions",
-        "realtime_trip_updates": "https://api.goswift.ly/real-time/avalon/gtfs-rt-trip-updates"
-      },
-      "license": {
-        "url": "https://www.goswift.ly/api-license"
-      },
-      "authorization": {
-        "type": "header",
-        "param_name": "Authorization",
-        "info_url": "https://goswift.ly/realtime-api-key"
-      }
-    },
-    {
       "id": "f-banning~pass~transit~rt",
       "spec": "gtfs-rt",
       "urls": {

--- a/scripts/debug/add_feed_tags.py
+++ b/scripts/debug/add_feed_tags.py
@@ -525,7 +525,6 @@ FEED_TAGS = [
     {"onestop_id":"f-eyckr-metrodelisboa","tags":{"source_webpage": "http://www.transporlis.pt/Default.aspx?tabid=254&language=pt-PT&codOp=13"}},
     {"onestop_id":"f-9r0-redding~ca~us","tags":{"feed_id": "redding-ca-us", "managed_by": "trillium", "gtfs_data_exchange": "redding-area-bus-authority"}},
     {"onestop_id":"f-9q5-vctc~ca~us","tags":{"feed_id": "vctc-ca-us"}},
-    {"onestop_id":"f-9mgve-avalon~ca~us","tags":{"feed_id": "avalon-ca-us"}},
     {"onestop_id":"f-9y7v-metropolitantulsatransitauthority","tags":{"gtfs_data_exchange": "metropolitan-tulsa-transit-authority"}},
     {"onestop_id":"f-f25g-omitsainte~julie","tags":{"gtfs_data_exchange": "omit-sainte-julie"}},
     {"onestop_id":"f-66tm-liserco~lincosur~lisanco","tags":{"unstable_url": "true"}},


### PR DESCRIPTION
Was completely replaced with microtransit in April.