### PR TITLE
Add real-time feed for NICTD

### DIFF
--- a/feeds/mysouthshoreline.com.dmfr.json
+++ b/feeds/mysouthshoreline.com.dmfr.json
@@ -14,6 +14,10 @@
           "associated_feeds": [
             {
               "gtfs_agency_id": "NICTD"
+            },
+            {
+              "feed_onestop_id": "f-northern~indiana~commuter~transportation~district~rt",
+              "gtfs_agency_id": "South Shore Line"
             }
           ],
           "tags": {
@@ -23,6 +27,15 @@
           }
         }
       ]
+    },
+    {
+      "id": "f-northern~indiana~commuter~transportation~district~rt",
+      "spec": "gtfs-rt",
+      "urls": {
+        "realtime_vehicle_positions": "https://s3.amazonaws.com/etatransit.gtfs/southshore.etaspot.net/position_updates.pb",
+        "realtime_trip_updates": "https://s3.amazonaws.com/etatransit.gtfs/southshore.etaspot.net/trip_updates.pb",
+        "realtime_alerts": "https://s3.amazonaws.com/etatransit.gtfs/southshore.etaspot.net/alerts.pb"
+      }
     }
   ],
   "license_spdx_identifier": "CDLA-Permissive-1.0"


### PR DESCRIPTION
This adds a real-time feed for NICTD, a Chicago-area interurban rail operator, based on data from ETA SPOT.

Unfortunately, there is a discrepancy in the GTFS agency ID between the GTFS static feed provided by mysouthshoreline.com and by ETA SPOT. I have not checked whether this discrepancy arises in the GTFS-RT data (I'd assume it does), since I can't read the protobufs.