### PR TITLE
Update Rockford RMTD GTFS

### DIFF
--- a/feeds/rmtd.org.dmfr.json
+++ b/feeds/rmtd.org.dmfr.json
@@ -5,7 +5,7 @@
       "id": "f-rockford~mass~transit~district",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://dfef8f.p3cdn2.secureserver.net/wp-content/uploads/2023/08/RMTD_GTFS_AUGUST_2023.zip"
+        "static_current": "https://rmtd.org/rmtdgtfs/GTFS_FILES.zip"
       },
       "tags": {
         "unstable_url": "true"
@@ -17,7 +17,7 @@
           "short_name": "RMTD",
           "website": "https://rmtd.org",
           "tags": {
-            "developer_site": "https://rmtd.org/gtfs/",
+            "developer_site": "https://rmtd.org/general-transit-feed-specification/",
             "us_ntd_id": "50058"
           }
         }


### PR DESCRIPTION
The URL has changed, and the new URL looks like it's going to last a while after updates. Real-time data is from Clever Devices, which we'll have to deal with separately.