### PR TITLE
Add Indian Railways feed from @Neo2308

### DIFF
--- a/feeds/indianrail.gov.in.dmfr.json
+++ b/feeds/indianrail.gov.in.dmfr.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://dmfr.transit.land/json-schema/dmfr.schema-v0.6.0.json",
+  "feeds": [
+    {
+      "id": "f-indianrailways",
+      "spec": "gtfs",
+      "urls": {
+        "static_current": "https://github.com/Neo2308/indianrailways-gtfs/raw/refs/heads/main/gtfs/gtfs.zip"
+      },
+      "license": {
+        "url": "https://github.com/Neo2308/indianrailways-gtfs/blob/main/README.md"
+      }
+    }
+  ],
+  "operators": [
+    {
+      "onestop_id": "o-indianrailways",
+      "name": "Indian Railways",
+      "associated_feeds": [
+        {
+          "gtfs_agency_id": "Indian Railways",
+          "feed_onestop_id": "f-indianrailways"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The feed is provided by https://github.com/Neo2308/indianrailways-gtfs, which coverts the data from Umang's API (Umang is the Indian government's single government services app, which has a lot of sub-applications for each government agency).

Issues:
* The actual expiration of the feed is not known, the expiration date listed is arbitrary
* The station names are not available, only station codes are.