### PR TITLE
Modified GTFS data for Delhi

### DIFF
--- a/feeds/otd.delhi.gov.in.dmfr.json
+++ b/feeds/otd.delhi.gov.in.dmfr.json
@@ -5,7 +5,7 @@
       "id": "f-delhi~bus",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://github.com/ethanc8/gtfs-mirror/raw/main/India/Delhi/OTD/GTFS.zip"
+        "static_current": "https://ethanc8.github.io/delhi-gtfs/bus.zip"
       },
       "license": {
         "url": "https://otd.delhi.gov.in/static/assets/terms-and-conditions.pdf"
@@ -15,7 +15,7 @@
       "id": "f-delhi~metro",
       "spec": "gtfs",
       "urls": {
-        "static_current": "https://github.com/ethanc8/gtfs-mirror/raw/main/India/Delhi/OTD/DMRC_GTFS.zip"
+        "static_current": "https://ethanc8.github.io/delhi-gtfs/metro.zip"
       },
       "license": {
         "url": "https://otd.delhi.gov.in/static/assets/terms-and-conditions.pdf"


### PR DESCRIPTION
## Changes from source data

* The bus data now expires on 2027-01-01, since we still have realtime data for buses
  * Even the official published timetables were never accurate
  * The realtime data cannot be used without a static feed
* The route IDs for the Metro have been consolidated, the route names are changed to be more user-friendly, and the route colors have been added