### PR TITLE
Add Zakroczym GTFS feed

### DIFF
--- a/feeds/feed.gtfs.cc.dmfr.json
+++ b/feeds/feed.gtfs.cc.dmfr.json
@@ -3,15 +3,17 @@
   "feeds": [
     {
       "id": "f-u3qd~zakroczym",
-      "name": "Zakroczym GTFS",  
+      "name": "Zakroczym GTFS",
       "spec": "gtfs",
       "urls": {
         "static_current": "https://feed.gtfs.cc/zakroczym/gtfs.zip"
       },
+      "languages": [
+        "pl-PL"
+      ],
       "license": {
         "spdx_identifier": "MIT"
       },
-      "languages": ["pl-PL"],
       "operators": [
         {
           "onestop_id": "o-u3qd~zakroczym",


### PR DESCRIPTION
This feed covers most of the Nowodworski district in Masovia.